### PR TITLE
Add role name and ARN to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "function_arn" {
 output "function_name" {
   value = var.name
 }
+
+output execution_role_arn {
+  value = aws_iam_role.lambda_at_edge.arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,10 @@ output "function_name" {
   value = var.name
 }
 
+output execution_role_name {
+  value = aws_iam_role.lambda_at_edge.name
+}
+
 output execution_role_arn {
   value = aws_iam_role.lambda_at_edge.arn
 }


### PR DESCRIPTION
Thanks so much for creating terraform-aws-lambda-at-edge! Solves my exact problem with no extra overhead.

I ran into a scenario where I wanted to attach an extra policy to the execution role, and therefore needed its name / arn as an output. Hope it helps someone else!

Cheers