### PR TITLE
Hotfix: avoid dynamic files at evaluation time

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,11 +6,11 @@
  * Lambdas are uploaded to via zip files, so we create a zip out of a given directory.
  * In the future, we may want to source our code from an s3 bucket instead of a local zip.
  */
-data archive_file zip_file_for_lambda {
+data "archive_file" "zip_file_for_lambda" {
   type        = "zip"
   output_path = "lambda_code.zip"
 
-  dynamic source {
+  dynamic "source" {
     for_each = distinct(flatten([
       for blob in var.file_globs :
       fileset(var.lambda_code_source_dir, blob)
@@ -25,7 +25,7 @@ data archive_file zip_file_for_lambda {
   }
 
   # Optionally write a `config.json` file if any plaintext params were given
-  dynamic source {
+  dynamic "source" {
     for_each = length(keys(var.plaintext_params)) > 0 ? ["true"] : []
     content {
       content  = jsonencode(var.plaintext_params)
@@ -40,18 +40,18 @@ data archive_file zip_file_for_lambda {
  * Doing this makes the plans more resiliant, where it won't always
  * appear that the function needs to be updated
  */
-resource aws_s3_bucket_object artifact {
-  bucket                 = var.s3_artifact_bucket
-  key                    = "${var.name}.zip"
-  source                 = data.archive_file.zip_file_for_lambda.output_path
-  etag                   = filemd5(data.archive_file.zip_file_for_lambda.output_path)
-  tags                   = var.tags
+resource "aws_s3_bucket_object" "artifact" {
+  bucket = var.s3_artifact_bucket
+  key    = "${var.name}.zip"
+  source = data.archive_file.zip_file_for_lambda.output_path
+  etag   = data.archive_file.zip_file_for_lambda.output_md5
+  tags   = var.tags
 }
 
 /**
  * Create the Lambda function. Each new apply will publish a new version.
  */
-resource aws_lambda_function lambda {
+resource "aws_lambda_function" "lambda" {
   function_name = var.name
   description   = var.description
 
@@ -76,7 +76,7 @@ resource aws_lambda_function lambda {
 /**
  * Policy to allow AWS to access this lambda function.
  */
-data aws_iam_policy_document assume_role_policy_doc {
+data "aws_iam_policy_document" "assume_role_policy_doc" {
   statement {
     sid    = "AllowAwsToAssumeRole"
     effect = "Allow"
@@ -98,7 +98,7 @@ data aws_iam_policy_document assume_role_policy_doc {
  * Make a role that AWS services can assume that gives them access to invoke our function.
  * This policy also has permissions to write logs to CloudWatch.
  */
-resource aws_iam_role lambda_at_edge {
+resource "aws_iam_role" "lambda_at_edge" {
   name               = "${var.name}-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy_doc.json
   tags               = var.tags
@@ -107,7 +107,7 @@ resource aws_iam_role lambda_at_edge {
 /**
  * Allow lambda to write logs.
  */
-data aws_iam_policy_document lambda_logs_policy_doc {
+data "aws_iam_policy_document" "lambda_logs_policy_doc" {
   statement {
     effect    = "Allow"
     resources = ["*"]
@@ -126,7 +126,7 @@ data aws_iam_policy_document lambda_logs_policy_doc {
 /**
  * Attach the policy giving log write access to the IAM Role
  */
-resource aws_iam_role_policy logs_role_policy {
+resource "aws_iam_role_policy" "logs_role_policy" {
   name   = "${var.name}at-edge"
   role   = aws_iam_role.lambda_at_edge.id
   policy = data.aws_iam_policy_document.lambda_logs_policy_doc.json
@@ -138,7 +138,7 @@ resource aws_iam_role_policy logs_role_policy {
  * logs in production will be logged to a log group in the region
  * of the CloudFront edge location handling the request.
  */
-resource aws_cloudwatch_log_group log_group {
+resource "aws_cloudwatch_log_group" "log_group" {
   name = "/aws/lambda/${var.name}"
   tags = var.tags
 }
@@ -146,7 +146,7 @@ resource aws_cloudwatch_log_group log_group {
 /**
  * Create the secret SSM parameters that can be fetched and decrypted by the lambda function.
  */
-resource aws_ssm_parameter params {
+resource "aws_ssm_parameter" "params" {
   for_each = var.ssm_params
 
   description = "param ${each.key} for the lambda function ${var.name}"
@@ -163,7 +163,7 @@ resource aws_ssm_parameter params {
 /**
  * Create an IAM policy document giving access to read and fetch the SSM params
  */
-data aws_iam_policy_document secret_access_policy_doc {
+data "aws_iam_policy_document" "secret_access_policy_doc" {
   count = length(var.ssm_params) > 0 ? 1 : 0
 
   statement {
@@ -183,7 +183,7 @@ data aws_iam_policy_document secret_access_policy_doc {
 /**
  * Create a policy from the SSM policy document
  */
-resource aws_iam_policy ssm_policy {
+resource "aws_iam_policy" "ssm_policy" {
   count = length(var.ssm_params) > 0 ? 1 : 0
 
   name        = "${var.name}-ssm-policy"
@@ -194,7 +194,7 @@ resource aws_iam_policy ssm_policy {
 /**
  * Attach the policy giving SSM param access to the Lambda IAM Role
  */
-resource aws_iam_role_policy_attachment ssm_policy_attachment {
+resource "aws_iam_role_policy_attachment" "ssm_policy_attachment" {
   count = length(var.ssm_params) > 0 ? 1 : 0
 
   role       = aws_iam_role.lambda_at_edge.id


### PR DESCRIPTION
Currently, this module doesn't pass the evaluation in Terraform 0.14.9 because the zip is not created in the evaluation stage so hashing the output_path result in "no files found". This is fixed in my version by instead passing output_md5 prop.  