### PR TITLE
use `source_code_hash` 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ resource aws_lambda_function lambda {
   s3_bucket         = var.s3_artifact_bucket
   s3_key            = aws_s3_bucket_object.artifact.id
   s3_object_version = aws_s3_bucket_object.artifact.version_id
+  source_code_hash  = filebase64sha256(data.archive_file.zip_file_for_lambda.output_path)
 
   publish = true
   handler = var.handler


### PR DESCRIPTION
to trigger an update to the lambda on S3 object change. Without the S3 object would be uploaded but the lambda would stick at the original version 