### PR TITLE
Avoid churn around IAM policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,8 +88,8 @@ data "aws_iam_policy_document" "assume_role_policy_doc" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
         "edgelambda.amazonaws.com",
+        "lambda.amazonaws.com",
       ]
     }
   }


### PR DESCRIPTION
With the order as it was, Terraform Cloud would report a change to the policy, presumably because the list coming back from AWS was sorted unlike the HCL.

```
  # module.security_headers.aws_iam_role.lambda_at_edge has been changed
  ~ resource "aws_iam_role" "lambda_at_edge" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Principal = {
                          ~ Service = [
                              - "edgelambda.amazonaws.com",
                                "lambda.amazonaws.com",
                              + "edgelambda.amazonaws.com",
                            ]
                        }
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
```

![image](https://user-images.githubusercontent.com/18374/129458073-bf4becab-309f-4305-9f0e-02a58c966c29.png)
