### PR TITLE
Add local_file_dir var for controlling where the zip file is written

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@
  */
 data "archive_file" "zip_file_for_lambda" {
   type        = "zip"
-  output_path = "${var.name}.zip"
+  output_path = "${var.local_file_dir}/${var.name}.zip"
 
   dynamic "source" {
     for_each = distinct(flatten([

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,11 @@ variable file_globs {
   description = "list of files or globs that you want included from the lambda_code_source_dir"
 }
 
+variable local_file_dir {
+  description = "A path to the directory to store plan time generated local files"
+  default     = "."
+}
+
 variable runtime {
   description = "The runtime of the lambda function"
   default     = "nodejs10.x"


### PR DESCRIPTION
## Related Issues
	
- The constraints of our CICD environment means that files generated at plan time are not available at apply time unless they are located where plan time state is copied forward to apply.
	
## Public Changelog
	
The addition of the `local_file_dir` variable which allows plan time files to be written to a specific location
	
## Security Implications
	
_[none]_
