### PR TITLE
Change default runtime

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable local_file_dir {
 
 variable runtime {
   description = "The runtime of the lambda function"
-  default     = "nodejs10.x"
+  default     = "nodejs14.x"
 }
 
 variable handler {


### PR DESCRIPTION
error creating Lambda Function (1): InvalidParameterValueException: The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions.

## Related Issues
	
- _[none]_
	
## Public Changelog
	
- change default runtime nodejs10.x -> nodejs14.x
	
## Security Implications
	
_[none]_
