### PR TITLE
add support to pass a kms to encrypt cloudwatch log groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -142,6 +142,7 @@ resource "aws_iam_role_policy" "logs_role_policy" {
 resource "aws_cloudwatch_log_group" "log_group" {
   name = "/aws/lambda/${var.name}"
   tags = var.tags
+  kms_key_id = var.cloudwatch_log_groups_kms_arn
 }
 
 /**

--- a/variables.tf
+++ b/variables.tf
@@ -60,7 +60,7 @@ variable plaintext_params {
   const config = JSON.parse(readFileSync('./config.json'))
   const someConfigValue = config.SomeKey
   ```
-  
+
   Compared to var.ssm_params, you should use this variable when you have non-secret things that you want very quick access
   to during the execution of your lambda function.
   EOF
@@ -71,7 +71,7 @@ variable ssm_params {
   default     = {}
   description = <<EOF
   Lambda@Edge does not support env vars, so it is a common pattern to exchange Env vars for SSM params.
-  
+
   So instead of using env vars like:
   `const someEnvValue = process.env.SOME_ENV`
 
@@ -92,3 +92,10 @@ variable ssm_params {
   in your lambda .zip file. These params will need to be fetched via a Promise at runtime, so there may be small performance delays.
   EOF
 }
+
+variable cloudwatch_log_groups_kms_arn {
+  type        = string
+  description = "KMS ARN to encrypt the log group in cloudwatch"
+  default     = null
+}
+


### PR DESCRIPTION
Added support for KMS encription on cloudwatch log groups

## Related Issues
	
- _[none]_
	
## Public Changelog

Added `cloudwatch_log_groups_kms_arn` as a variable. You can pass the ARN of a KMS resource and it will be used to encript the cloudwatch log groups.
	
## Security Implications
	
_[none]_
