### PR TITLE
Fix deprecation warnings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ data "archive_file" "zip_file_for_lambda" {
  * Doing this makes the plans more resiliant, where it won't always
  * appear that the function needs to be updated
  */
-resource "aws_s3_bucket_object" "artifact" {
+resource "aws_s3_object" "artifact" {
   bucket = var.s3_artifact_bucket
   key    = "${var.name}.zip"
   source = data.archive_file.zip_file_for_lambda.output_path
@@ -57,8 +57,8 @@ resource "aws_lambda_function" "lambda" {
 
   # Find the file from S3
   s3_bucket         = var.s3_artifact_bucket
-  s3_key            = aws_s3_bucket_object.artifact.id
-  s3_object_version = aws_s3_bucket_object.artifact.version_id
+  s3_key            = aws_s3_object.artifact.id
+  s3_object_version = aws_s3_object.artifact.version_id
   source_code_hash  = filebase64sha256(data.archive_file.zip_file_for_lambda.output_path)
 
   publish = true

--- a/main.tf
+++ b/main.tf
@@ -66,12 +66,6 @@ resource "aws_lambda_function" "lambda" {
   runtime = var.runtime
   role    = aws_iam_role.lambda_at_edge.arn
   tags    = var.tags
-
-  lifecycle {
-    ignore_changes = [
-      last_modified,
-    ]
-  }
 }
 
 /**


### PR DESCRIPTION
There were two changes that needed to happen to get rid of the warnings:

1. Replace `aws_s3_bucket_object` (now deprecated) to `aws_bucket_object`
2. Remove `ignore_changes`

The individual commits contain more information about each of those changes.

Note that the change from `aws_s3_bucket_object` to `aws_bucket_object` will result in the resource being recreated, so that may a consideration when changing the version number.
